### PR TITLE
Ignore backup files and swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.*.sw?
+*~
 /vim-lang-ja*.tar.gz
 /vim-lang-ja*.tar.bz2
 /vim-lang-ja*.tar.xz


### PR DESCRIPTION
Vimのバックアップファイルとスワップファイルを .gitignore に追加しました。