### PR TITLE
Use 'make merge'

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -24,11 +24,9 @@ src/po/ 及び runtime/lang/ 配下の、上記以外のファイルは基本的
         $ cd src/po
         $ make vim.pot
 
-2.  ja.po に vim.pot をマージ (古いのは ja.po.old へ退避)
+2.  ja.po に vim.pot をマージ (古いのは ja.po.old へ退避します)
 
         $ make merge
-        $ mv ja.po ja.po.old
-        $ mv ja.po.new ja.po
 
 3.  ja.po のコピーライトやヘッダーを適宜修正
 
@@ -55,8 +53,6 @@ src/po/ 及び runtime/lang/ 配下の、上記以外のファイルは基本的
 7.  もう1回マージして、整形と消しすぎたコメントの復活
 
         $ make merge
-        $ mv ja.po ja.po.bak
-        $ mv ja.po.new ja.po
         $ vim ja.po
         :source cleanup.vim
         :wq

--- a/README.mkd
+++ b/README.mkd
@@ -26,8 +26,9 @@ src/po/ 及び runtime/lang/ 配下の、上記以外のファイルは基本的
 
 2.  ja.po に vim.pot をマージ (古いのは ja.po.old へ退避)
 
+        $ make merge
         $ mv ja.po ja.po.old
-        $ msgmerge ja.po.old vim.pot -o ja.po
+        $ mv ja.po.new ja.po
 
 3.  ja.po のコピーライトやヘッダーを適宜修正
 
@@ -51,10 +52,11 @@ src/po/ 及び runtime/lang/ 配下の、上記以外のファイルは基本的
 
         $ vim -S check.vim ja.po
 
-7.  もう1回msgmergeして、整形と消しすぎたコメントの復活
+7.  もう1回マージして、整形と消しすぎたコメントの復活
 
+        $ make merge
         $ mv ja.po ja.po.bak
-        $ msgmerge ja.po.bak vim.pot -o ja.po
+        $ mv ja.po.new ja.po
         $ vim ja.po
         :source cleanup.vim
         :wq

--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -20,10 +20,12 @@ force: touch
 touch: $(MASTER_PO)
 	touch $<
 
-merge: ja.po.new
+merge: ja.po
 
 clean:
 	rm -f sjiscorr sjiscorr.exe
 
-ja.po.new: vim.pot
-	msgmerge ja.po vim.pot -o $@
+ja.po: vim.pot
+	rm -f $@.old
+	mv $@ $@.old
+	msgmerge $@.old $< -o $@


### PR DESCRIPTION
せっかく `make merge` があるので、READMEもそれを使うように直してみたのですが、どうでしょうか。

古いファイルを vim.po.old 等に退避するのも make merge でまとめてやってくれた方が便利かと思ったのですが、そこは手を付けていません。