### PR TITLE
Don't translate Cygwin pty error

### DIFF
--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -2868,8 +2868,9 @@ msgstr "スクリプト出力用を開けません"
 msgid "Vim: Error: Failure to start gvim from NetBeans\n"
 msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
 
+#  This should not be translated, otherwise it causes mojibake.
 msgid "Vim: Error: This version of Vim does not run in a Cygwin terminal\n"
-msgstr "Vim: エラー: このバージョンのVimはCygwin端末では動作しません\n"
+msgstr "Vim: Error: This version of Vim does not run in a Cygwin terminal\n"
 
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 端末への出力ではありません\n"


### PR DESCRIPTION
mintty等のCygwin pty上でWin32 vim.exeを実行したときに表示されるエラーメッセージを翻訳しないようにしました。
minttyは（通常）文字列が UTF-8 であることを期待していますが、vim.exe は CP932 で出力するので確実に文字化けが起こるためです。

メモ:
https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
`#␣ ` で始まるコメントは翻訳者によるコメント。