### PR TITLE
Additional update for PR #86

### DIFF
--- a/src/po/Makefile
+++ b/src/po/Makefile
@@ -25,7 +25,7 @@ ja.sjis.po: $(MASTER_PO)
 
 ja.euc-jp.po: $(MASTER_PO)
 	iconv -f utf-8 -t euc-jp $< | \
-	  sed -e 's/charset=utf-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > $@
+	  sed -e 's/charset=[uU][tT][fF]-8/charset=euc-jp/' -e 's/# Original translations/# Generated from ja.po, DO NOT EDIT/' > $@
 
 sjiscorr: sjiscorr.c
 	$(CC) -o $@ $<

--- a/src/po/sjiscorr.c
+++ b/src/po/sjiscorr.c
@@ -16,7 +16,8 @@ main(int argc, char **argv)
 	{
 		for (p = buffer; *p != 0; p++)
 		{
-			if (strncmp(p, "charset=utf-8", 13) == 0)
+			if (strncmp(p, "charset=utf-8", 13) == 0
+				|| strncmp(p, "charset=UTF-8", 13) == 0)
 			{
 				fputs("charset=cp932", stdout);
 				p += 12;

--- a/src/po/sjiscorr.c
+++ b/src/po/sjiscorr.c
@@ -7,9 +7,7 @@
 #include <string.h>
 
 	int
-main(argc, argv)
-	int	argc;
-	char	**argv;
+main(int argc, char **argv)
 {
 	char buffer[BUFSIZ];
 	char *p;


### PR DESCRIPTION
"charset" was changed from "utf-8" to "UTF-8" by #86.
Now we also need to update `Makefile` and `sjiscorr.c`.

I have already sent a patch for this to vim_dev: https://groups.google.com/d/msg/vim_dev/jKafrZVo2xU/26jGEfiyBQAJ