### PR TITLE
Import the latest check.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ runtime/tutor/tutor |原文チュートリアルファイル
 
         :source cleanup.vim
 
-    cleanup.vim は Vim 本体からのコピー
+    cleanup.vim は Vim 本体からのコピー (実行には Vim 8.0.0794 以降が必要)
 
 6.  チェック
 

--- a/src/po/check.vim
+++ b/src/po/check.vim
@@ -35,6 +35,7 @@ let s:save_wrapscan = &wrapscan
 set nowrapscan
 
 " Start at the first "msgid" line.
+let wsv = winsaveview()
 1
 /^msgid\>
 
@@ -110,9 +111,99 @@ if search('msgid "\("\n"\)\?\([EW][0-9]\+:\).*\nmsgstr "\("\n"\)\?[^"]\@=\2\@!')
   endif
 endif
 
+func! CountNl(first, last)
+  let nl = 0
+  for lnum in range(a:first, a:last)
+    let nl += count(getline(lnum), "\n")
+  endfor
+  return nl
+endfunc
+
+" Check that the \n at the end of the msgid line is also present in the msgstr
+" line.  Skip over the header.
+1
+/^"MIME-Version:
+while 1
+  let lnum = search('^msgid\>')
+  if lnum <= 0
+    break
+  endif
+  let strlnum = search('^msgstr\>')
+  let end = search('^$')
+  if end <= 0
+    let end = line('$') + 1
+  endif
+  let origcount = CountNl(lnum, strlnum - 1)
+  let transcount = CountNl(strlnum, end - 1)
+  " Allow for a few more or less line breaks when there are 2 or more
+  if origcount != transcount && (origcount <= 2 || transcount <= 2)
+    echomsg 'Mismatching "\n" in line ' . line('.')
+    if error == 0
+      let error = lnum
+    endif
+  endif
+endwhile
+
+" Check that the file is well formed according to msgfmts understanding
+if executable("msgfmt")
+  let filename = expand("%")
+  " Newer msgfmt does not take OLD_PO_FILE_INPUT argument, must be in
+  " environment.
+  let $OLD_PO_FILE_INPUT = 'yes'
+  let a = system("msgfmt --statistics " . filename)
+  if v:shell_error != 0
+    let error = matchstr(a, filename.':\zs\d\+\ze:')+0
+    for line in split(a, '\n') | echomsg line | endfor
+  endif
+endif
+
+" Check that the plural form is properly initialized
+1
+let plural = search('^msgid_plural ', 'n')
+if (plural && search('^"Plural-Forms: ', 'n') == 0) || (plural && search('^msgstr\[0\] ".\+"', 'n') != plural + 1)
+  if search('^"Plural-Forms: ', 'n') == 0
+    echomsg "Missing Plural header"
+    if error == 0
+      let error = search('\(^"[A-Za-z-_]\+: .*\\n"\n\)\+\zs', 'n') - 1
+    endif
+  elseif error == 0
+    let error = plural
+  endif
+elseif !plural && search('^"Plural-Forms: ', 'n')
+  " We allow for a stray plural header, msginit adds one.
+endif
+
+" Check that 8bit encoding is used instead of 8-bit
+let cte = search('^"Content-Transfer-Encoding:\s\+8-bit', 'n')
+let ctc = search('^"Content-Type:.*;\s\+\<charset=[iI][sS][oO]_', 'n')
+let ctu = search('^"Content-Type:.*;\s\+\<charset=utf-8', 'n')
+if cte
+  echomsg "Content-Transfer-Encoding should be 8bit instead of 8-bit"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = cte
+  " endif
+elseif ctc
+  echomsg "Content-Type charset should be 'ISO-...' instead of 'ISO_...'"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = ct
+  " endif
+elseif ctu
+  echomsg "Content-Type charset should be 'UTF-8' instead of 'utf-8'"
+  " TODO: make this an error
+  " if error == 0
+  "   let error = ct
+  " endif
+endif
+
+
 if error == 0
+  " If all was OK restore the view.
+  call winrestview(wsv)
   echomsg "OK"
 else
+  " Put the cursor on the line with the error.
   exe error
 endif
 


### PR DESCRIPTION
Import check.vim from Vim 8.1.0111.
This requires Vim 8.0.0794 or later, but it should be okay because our CI always builds the latest version of Vim.