### PR TITLE
tutor: Add vim-jp team as translators

### DIFF
--- a/runtime/tutor/tutor.ja.utf-8
+++ b/runtime/tutor/tutor.ja.utf-8
@@ -969,8 +969,9 @@ NOTE: 補完は多くのコマンドで動作します。そして CTRL-D と <T
 
   Modified for Vim by Bram Moolenaar.
 
-  日本語訳  松本 泰弘  <mattn.jp@gmail.com>
-  監修      村岡 太郎  <koron.kaoriya@gmail.com>
+  日本語訳  松本 泰弘    <mattn.jp@gmail.com>
+            vim-jpチーム <https://github.com/vim-jp/lang-ja>
+  監修      村岡 太郎    <koron.kaoriya@gmail.com>
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  vi:set ts=8 sts=4 sw=4 tw=78:


### PR DESCRIPTION
現在 tutor の翻訳者は @mattn さんが記載されていますが、現在は lang-ja で管理していることですし、vim-jpチームを翻訳者として追加したいと思いますが、どうでしょうか。

（間違いなどを見つけたときに、vim_dev 等ではなく lang-ja に連絡して欲しいという意図もあります。）