### PR TITLE
Add no-c-format comment

### DIFF
--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -3524,6 +3524,7 @@ msgstr "   ディレクトリ "
 msgid "      -- none --\n"
 msgstr "      -- なし --\n"
 
+#, no-c-format
 msgid "%a %b %d %H:%M:%S %Y"
 msgstr "%Y/%m/%d (%a) %H:%M:%S"
 


### PR DESCRIPTION
Work around for an error reported by check.vim.

See also: https://groups.google.com/d/msg/vim_dev/R5x1T6TpQDc/jrBQB_VnBAAJ