### PR TITLE
Don't translate the message for Cygwin terminal error

### DIFF
--- a/src/po/ja.po
+++ b/src/po/ja.po
@@ -2835,8 +2835,9 @@ msgstr "スクリプト出力用を開けません"
 msgid "Vim: Error: Failure to start gvim from NetBeans\n"
 msgstr "Vim: エラー: NetBeansからgvimをスタートできません\n"
 
+#  This message should be English to avoid mojibake.
 msgid "Vim: Error: This version of Vim does not run in a Cygwin terminal\n"
-msgstr "Vim: エラー: このバージョンのVimはCygwin端末では動作しません\n"
+msgstr "Vim: Error: This version of Vim does not run in a Cygwin terminal\n"
 
 msgid "Vim: Warning: Output is not to a terminal\n"
 msgstr "Vim: 警告: 端末への出力ではありません\n"


### PR DESCRIPTION
This message caused mojibake on mintty.

Before Cygwin 3.1.0, Cygwin didn't convert the encoding of Win32
programs. So, the error message is shown correctly when vim.exe outputs
the message in UTF-8.
However, starting from Cygwin 3.1.0, Cygwin supports ConPTY and also
converts the encoding of output from Win32 programs from current
codepage (cp932) to UTF-8. This doesn't cause any problems when
Windows 10 1809 or later is used, because vim.exe will work fine inside
mintty because of ConPTY.
However, this causes mojibake on Windows 10 1803 or earlier which
doesn't support ConPTY.

To show the error message correctly on all environments (Cygwin 3.0.7 or
3.1.0, Windows 10 1803 or 1809), the message should not be translated.