### PR TITLE
Update menu files for 8.2.4420

### DIFF
--- a/runtime/lang/Makefile
+++ b/runtime/lang/Makefile
@@ -6,11 +6,17 @@ update: menu_ja_jp.euc-jp.vim menu_japanese_japan.932.vim
 
 menu_ja_jp.euc-jp.vim: $(MASTER_MENU)
 	iconv -f utf-8 -t euc-jp $< | \
-	  sed -e 's/^scriptencoding utf-8/scriptencoding euc-jp/' -e 's/Menu Translations:\tJapanese (UTF-8)/Menu Translations:\tJapanese (EUC-JP)/' > $@
+	  sed -e 's/^scriptencoding utf-8/scriptencoding euc-jp/' \
+		-e 's/" Original translations/" Generated from $<, DO NOT EDIT/' \
+		-e 's/Menu Translations:\tJapanese (UTF-8)/Menu Translations:\tJapanese (EUC-JP)/' \
+		> $@
 
 menu_japanese_japan.932.vim: $(MASTER_MENU)
 	iconv -f utf-8 -t cp932 $< | \
-	  sed -e 's/^scriptencoding utf-8/scriptencoding cp932/' -e 's/Menu Translations:\tJapanese (UTF-8)/Menu Translations:\tJapanese (CP932)/' > $@
+	  sed -e 's/^scriptencoding utf-8/scriptencoding cp932/' \
+		-e 's/" Original translations/" Generated from $<, DO NOT EDIT/' \
+		-e 's/Menu Translations:\tJapanese (UTF-8)/Menu Translations:\tJapanese (CP932)/' \
+		> $@
 
 force: touch
 	@$(MAKE) update

--- a/runtime/lang/menu_ja_jp.utf-8.vim
+++ b/runtime/lang/menu_ja_jp.utf-8.vim
@@ -3,6 +3,7 @@
 " Menu Translations:	Japanese (UTF-8)
 " Last Translator:	MURAOKA Taro  <koron.kaoriya@gmail.com>
 " Last Change:		18-Jul-2018.
+" Original translations
 "
 " Copyright (C) 2001-2018 MURAOKA Taro <koron.kaoriya@gmail.com>,
 "			  vim-jp <http://vim-jp.org/>

--- a/runtime/lang/menu_ja_jp.utf-8.vim
+++ b/runtime/lang/menu_ja_jp.utf-8.vim
@@ -3,12 +3,13 @@
 " Menu Translations:	Japanese (UTF-8)
 " Last Translator:	MURAOKA Taro  <koron.kaoriya@gmail.com>
 " Last Change:		18-Jul-2018.
-" Original translations
 "
 " Copyright (C) 2001-2018 MURAOKA Taro <koron.kaoriya@gmail.com>,
 "			  vim-jp <http://vim-jp.org/>
 "
 " THIS FILE IS DISTRIBUTED UNDER THE VIM LICENSE.
+"
+" Original translations
 
 " Quit when menu translations have already been done.
 if exists("did_menu_trans")


### PR DESCRIPTION
Add the "Original translations" comment to follow [8.2.4420](https://github.com/vim/vim/commit/a42535340a906d33173e8b3e82085c161a0524c8).
Move the comment after the license notation as the same as `ja.po`.