### PR TITLE
Update makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*.sw?
 *~
+*.log
 /tmp/
 /vim-lang-ja*.tar.gz
 /vim-lang-ja*.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ release-today:
 
 test:
 	$(MAKE) -C src/po test
+	$(MAKE) -C runtime/doc test
 	$(MAKE) -C runtime/lang test
 	$(MAKE) -C runtime/tutor test
 
@@ -74,6 +75,7 @@ clean:
 	rm -rf $(ARCHIVE_DIR) $(ARCHIVE_FILE)
 	rm -rf $(INSTALL_DIR)
 	$(MAKE) -C src/po clean
+	$(MAKE) -C runtime/doc clean
 	$(MAKE) -C runtime/lang clean
 	$(MAKE) -C runtime/tutor clean
 

--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,51 @@ ARCHIVE_EXT = xz
 ARCHIVE_DIR = $(ARCHIVE)
 ARCHIVE_FILE = $(ARCHIVE).tar.$(ARCHIVE_EXT)
 
+VIM_SRC_DIR =
+
 INSTALL_DIR = $(ARCHIVE)-runtime
+
+.PHONY: import-en-files update-src-dir \
+	archive archive-dir release release-today test install clean distclean \
+	force-update-all force-update-po force-update-lang force-update-tutor
+
+
+# Import English files from the specified Vim source directory.
+import-en-files:
+	@if test ! -d "$(VIM_SRC_DIR)"; then echo VIM_SRC_DIR not specified; exit 1; fi
+	$(MAKE) -C "$(VIM_SRC_DIR)"/src/po/ vim.pot
+	cp "$(VIM_SRC_DIR)"/src/po/vim.pot src/po/
+	cp "$(VIM_SRC_DIR)"/runtime/doc/evim.1 \
+		"$(VIM_SRC_DIR)"/runtime/doc/vim.1 \
+		"$(VIM_SRC_DIR)"/runtime/doc/vimdiff.1 \
+		"$(VIM_SRC_DIR)"/runtime/doc/vimtutor.1 \
+		"$(VIM_SRC_DIR)"/runtime/doc/xxd.1 \
+		runtime/doc/
+	cp "$(VIM_SRC_DIR)"/runtime/tutor/tutor runtime/tutor/
+	cp "$(VIM_SRC_DIR)"/nsis/lang/english.nsi nsis/lang/
+
+# Update Vim source directory.
+update-src-dir:
+	@if test ! -d "$(VIM_SRC_DIR)"; then echo VIM_SRC_DIR not specified; exit 1; fi
+	@rm -rf $(ARCHIVE_DIR)
+	$(MAKE) test
+	$(MAKE) $(ARCHIVE_DIR)
+	cp -rf $(ARCHIVE_DIR)/* "$(VIM_SRC_DIR)"
+	rm -rf $(ARCHIVE_DIR)
+
 
 archive: $(ARCHIVE_FILE)
 
 archive-dir: $(ARCHIVE_DIR)
 
+# Create release package with the specified archive name.
 release: force-update-all
 	@rm -rf $(ARCHIVE_DIR) $(ARCHIVE_FILE)
 	$(MAKE) test
 	$(MAKE) $(ARCHIVE_FILE)
 	rm -rf $(ARCHIVE_DIR)
 
+# Create release package based on today's date.
 release-today:
 	$(MAKE) release ARCHIVE=vim-lang-ja-`date +%Y%m%d`
 
@@ -23,6 +56,7 @@ test:
 	$(MAKE) -C runtime/lang test
 	$(MAKE) -C runtime/tutor test
 
+# Install the message files into the specified (runtime) directory.
 install: test
 	mkdir -p $(INSTALL_DIR)/lang/ja/LC_MESSAGES
 	mkdir -p $(INSTALL_DIR)/lang/ja.euc-jp/LC_MESSAGES
@@ -62,10 +96,12 @@ $(ARCHIVE_DIR):
 	mkdir -p $@/runtime/lang
 	mkdir -p $@/runtime/doc
 	mkdir -p $@/runtime/tutor
+	mkdir -p $@/nsis/lang
 	cp src/po/*.po $@/src/po
 	cp runtime/lang/menu_ja*.vim $@/runtime/lang
 	cp runtime/doc/*.UTF-8.1 $@/runtime/doc
 	cp runtime/tutor/tutor.ja.* $@/runtime/tutor
+	cp nsis/lang/japanese.nsi $@/nsis/lang
 
 $(ARCHIVE).tar.gz: $(ARCHIVE_DIR)
 	tar -czf $@ $<

--- a/README.md
+++ b/README.md
@@ -18,9 +18,22 @@ runtime/tutor/tutor.ja.utf-8       |日本語チュートリアルファイル(U
 runtime/tutor/tutor                |原文チュートリアルファイル
 nsis/lang                          |Windows用インストーラーの翻訳ファイル
 
+## 原文ファイル取り込み手順
+
+以下のコマンドを実行して原文ファイルを現在の作業ディレクトリに取り込む。
+(`VIM_SRC_DIR` で Vim のソースディレクトリを指定)
+
+    $ make import-en-files VIM_SRC_DIR=../vim
+
+この手順では、vim.pot ファイル、man ファイル、チュートリアルファイル、NSIS ファイルの原文ファイルをまとめて取り込む。個別に取り込む場合や注意事項は以下のそれぞれの項目を参照のこと。
+
+メニューファイルについては、原文ファイルにあたるものがないので、取り込みは行わない。`runtime/menu.vim` などの履歴を見て手動で適宜更新する必要がある。
+
 ## ja.po 更新手順
 
 1.  vim.pot を作成(要xgettext)
+
+    (前述の原文ファイル取り込み手順を実施済みであれば不要。)
 
     Vimのソースで以下を実行して、生成される vim.pot を src/po へコピー
 
@@ -31,8 +44,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
     要があるが、`src/po/Makefile` の4行目の `include ../auto/config.mk` をコメ
     ントアウトして回避することも可能。(あるいは、空の `src/auto/config.mk` を用意してもよい。)
 
-    Windows 上で vim.pot を生成するには、Cygwin や MSYS2 等の Linux 的な環境を使うこと。(MSVC 用の Makefile も用意されているが、ソースファイルの読み込み順序が異なるために余計な差分が出てしまう。)
-    また、Win32 向けにビルドしたために `src/if_perl.c` が生成されているならば、vim.pot 生成前に削除しておくこと。(余計な差分が出るのを防ぐため。)
+    Windows 上で vim.pot を生成するには、Cygwin や MSYS2 等の Linux 的な環境を使うこと。(MSVC 用の Makefile も用意されているが、ソースファイルの読み込み順序が異なるために余計な差分が出てしまう。)  
+    また、古いソースを使って Win32 向けにビルドしたことで `src/if_perl.c` が残っているならば、vim.pot 生成前に削除しておくこと。(余計な差分が出るのを防ぐため。)
 
 2.  ja.po に vim.pot をマージ (古いものは ja.po.old へ退避される)
 
@@ -73,6 +86,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
 1.  原文manファイルの更新
 
+    (前述の原文ファイル取り込み手順を実施済みであれば不要。)
+
     Vimのソースファイルの runtime/doc/ ディレクトリから、原文manファイルを本リ
     ポジトリにコピー。
 
@@ -109,6 +124,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
 1.  原文チュートリアルファイルの更新
 
+    (前述の原文ファイル取り込み手順を実施済みであれば不要。)
+
     Vimのソースファイルの runtime/tutor/ ディレクトリから、原文チュートリアル
     ファイルを本リポジトリにコピー。
 
@@ -124,6 +141,35 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 3.  コミット
 
     原文と日本語訳は常に同じバージョンがコミットされているように注意すること。
+
+## NSIS ファイル更新手順
+
+1.  原文 NSIS ファイルの更新
+
+    (前述の原文ファイル取り込み手順を実施済みであれば不要。)
+
+    Vimのソースファイルの nsis/lang/ ディレクトリから、原文 NSIS ファイルを
+    本リポジトリにコピー。
+
+        $ cd /path/to/vim/nsis/lang
+        $ cp english.nsi /path/to/lang-ja/nsis/lang
+
+2.  翻訳
+
+    原文の差分を見つつ翻訳ファイルを更新する。
+
+        $ git diff | gvim -R -
+
+3.  コミット
+
+    原文と日本語訳は常に同じバージョンがコミットされているように注意すること。
+
+## メニューファイル更新手順
+
+1.  Vim のソースディレクトリに行き、`runtime/menu.vim` や `runtime/lang/` の履歴を調べる。
+
+2. 必要な変更を `runtime/lang/menu_ja*.vim` に反映する。
+
 
 ## リリース手順
 
@@ -158,7 +204,14 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
     `vim-lang-ja-po-YYYYMMDD.tar.xz` といったアーカイブファイルができる。
     `YYYYMMDD` の部分は実行した日付に置き換わる。
 
-5.  タグを打ち、GitHub Releases を更新する
+5.  Vim のソースディレクトリを更新する
+
+    GitHub に PR を出す場合は、以下のコマンドを実行して Vim のソースディレクトリを更新する。
+    (`VIM_SRC_DIR` で Vim のソースディレクトリを指定)
+
+        $ make update-src-dir VIM_SRC_DIR=../vim
+
+6.  タグを打ち、GitHub Releases を更新する
 
     タグの形式は YYYYMMDD とする。例:
 
@@ -168,9 +221,11 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
     タグが push できたら、GitHub Releases に新しいリリースを作り、アーカイブ
     をアップロードする。
 
-6.  アーカイブを Bram と vim-dev へ送る
+7.  Bram に対してリリースする
 
-    あとはこのアーカイブファイルを Bram と vim-dev へ更新依頼とともに送信する。
+    [GitHub][#github] に PR を出す。
+
+    あるいはこのアーカイブファイルを Bram と vim-dev へ更新依頼とともに送信する。
     以下、文面の一例:
 
         Hi Bram and the list,
@@ -183,8 +238,6 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
         Thanks,
         (ここにあなたの名前。`Takata`とか)
-
-    あるいは [GitHub][#github] に PR を出す。
 
 
 [#ci]:https://github.com/vim-jp/lang-ja/actions

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
     $ make import-en-files VIM_SRC_DIR=../vim
 
-この手順では、vim.pot ファイル、man ファイル、チュートリアルファイル、NSIS ファイルの原文ファイルをまとめて取り込む。個別に取り込む場合や注意事項は以下のそれぞれの項目を参照のこと。
+この手順では、vim.pot ファイル、man ファイル、チュートリアルファイル、NSIS
+ファイルの原文ファイルをまとめて取り込む。個別に取り込む場合や注意事項は以下の
+それぞれの項目を参照のこと。
 
-メニューファイルについては、原文ファイルにあたるものがないので、取り込みは行わない。`runtime/menu.vim` などの履歴を見て手動で適宜更新する必要がある。
+メニューファイルについては、原文ファイルにあたるものがないので、取り込みは行わ
+ない。`runtime/menu.vim` などの履歴を見て手動で適宜更新する必要がある。
 
 ## ja.po 更新手順
 
@@ -42,10 +45,15 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
     註: `make vim.pot` を実行するには `src/` で `./configure` を実行しておく必
     要があるが、`src/po/Makefile` の4行目の `include ../auto/config.mk` をコメ
-    ントアウトして回避することも可能。(あるいは、空の `src/auto/config.mk` を用意してもよい。)
+    ントアウトして回避することも可能。(あるいは、空の `src/auto/config.mk` を
+    用意してもよい。)
 
-    Windows 上で vim.pot を生成するには、Cygwin や MSYS2 等の Linux 的な環境を使うこと。(MSVC 用の Makefile も用意されているが、ソースファイルの読み込み順序が異なるために余計な差分が出てしまう。)  
-    また、古いソースを使って Win32 向けにビルドしたことで `src/if_perl.c` が残っているならば、vim.pot 生成前に削除しておくこと。(余計な差分が出るのを防ぐため。)
+    Windows 上で vim.pot を生成するには、Cygwin や MSYS2 等の Linux 的な環境を
+    使うこと。(MSVC 用の Makefile も用意されているが、ソースファイルの読み込み
+    順序が異なるために余計な差分が出てしまう。)  
+    また、古いソースを使って Win32 向けにビルドしたことで `src/if_perl.c` が
+    残っているならば、vim.pot 生成前に削除しておくこと。(余計な差分が出るのを
+    防ぐため。)
 
 2.  ja.po に vim.pot をマージ (古いものは ja.po.old へ退避される)
 
@@ -112,7 +120,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
         $ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z vim-ja.UTF-8.1 2>&1 > /dev/null | grep -v "cannot adjust line\|can't break line"
 
-    (末尾の `grep -v` は、日本語の場合に大量に表示される `cannot adjust line` と `can't break line` を除外するためのもの。)
+    (末尾の `grep -v` は、日本語の場合に大量に表示される `cannot adjust line`
+    と `can't break line` を除外するためのもの。)
 
     参照: <https://lintian.debian.org/tags/manpage-has-errors-from-man.html>
 
@@ -166,7 +175,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
 ## メニューファイル更新手順
 
-1.  Vim のソースディレクトリに行き、`runtime/menu.vim` や `runtime/lang/` の履歴を調べる。
+1.  Vim のソースディレクトリに行き、`runtime/menu.vim` や `runtime/lang/` の
+    履歴を調べる。
 
 2. 必要な変更を `runtime/lang/menu_ja*.vim` に反映する。
 
@@ -206,7 +216,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
 5.  Vim のソースディレクトリを更新する
 
-    GitHub に PR を出す場合は、以下のコマンドを実行して Vim のソースディレクトリを更新する。
+    GitHub に PR を出す場合は、以下のコマンドを実行して Vim のソースディレクト
+    リを更新する。
     (`VIM_SRC_DIR` で Vim のソースディレクトリを指定)
 
         $ make update-src-dir VIM_SRC_DIR=../vim
@@ -225,7 +236,8 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
     [GitHub][#github] に PR を出す。
 
-    あるいはこのアーカイブファイルを Bram と vim-dev へ更新依頼とともに送信する。
+    あるいはこのアーカイブファイルを Bram と vim-dev へ更新依頼とともに送信す
+    る。
     以下、文面の一例:
 
         Hi Bram and the list,

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ nsis/lang                          |Windows用インストーラーの翻訳フ�
 
     以下のコマンドでmanの文法に違反していないかチェックできる。
 
+        $ make test
+
+    ファイル単体をチェックする場合は以下のコマンドを使う。
+
         $ LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z vim-ja.UTF-8.1 2>&1 > /dev/null | grep -v "cannot adjust line\|can't break line"
 
     (末尾の `grep -v` は、日本語の場合に大量に表示される `cannot adjust line`

--- a/runtime/doc/Makefile
+++ b/runtime/doc/Makefile
@@ -1,0 +1,16 @@
+JA_FILES = \
+	   evim-ja.UTF-8.1 \
+	   vimdiff-ja.UTF-8.1 \
+	   vim-ja.UTF-8.1 \
+	   vimtutor-ja.UTF-8.1 \
+	   xxd-ja.UTF-8.1
+
+test:
+	for i in $(JA_FILES); do \
+		echo Checking $$i; \
+		LC_ALL=en_US.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z $$i > $$i.log 2>&1 > /dev/null; \
+		grep -v "cannot adjust line\|can't break line" $$i.log && exit 1 || :; \
+	done
+
+clean:
+	rm -f *.log

--- a/runtime/lang/Makefile
+++ b/runtime/lang/Makefile
@@ -1,6 +1,6 @@
 MASTER_MENU = menu_ja_jp.utf-8.vim
 
-test:
+test: update
 
 update: menu_ja_jp.euc-jp.vim menu_japanese_japan.932.vim
 


### PR DESCRIPTION
* Makefileを更新
  - Vim のソースディレクトリから原文ファイルを簡単に取り込んだり、翻訳ファイルを簡単に Vim のソースディレクトリに反映できるようにするため、ターゲットとして `import-en-files` と `update-src-dir` を追加。
  - コメントを追加。
  - .PHONY を追加。
  - NSIS ファイルをリリースパッケージに追加。
* READMEを更新
  - `import-en-files` と `update-src-dir` について記載。
  - メニューファイルと NSIS ファイルの更新方法について記載。
  - 古い内容を見直し。
* runtime/doc/Makefile を追加
  - man ファイルの文法チェックを `make test` で実施するようにした。