### PR TITLE
New target import-scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VIM_SRC_DIR =
 
 INSTALL_DIR = $(ARCHIVE)-runtime
 
-.PHONY: import-en-files update-src-dir \
+.PHONY: import-en-files import-scripts update-src-dir \
 	archive archive-dir release release-today test install clean distclean \
 	force-update-all force-update-po force-update-lang force-update-tutor
 
@@ -26,6 +26,13 @@ import-en-files:
 	cp "$(VIM_SRC_DIR)"/runtime/tutor/tutor1 runtime/tutor/
 	cp "$(VIM_SRC_DIR)"/runtime/tutor/tutor2 runtime/tutor/
 	cp "$(VIM_SRC_DIR)"/nsis/lang/english.nsi nsis/lang/
+
+# Import and update the .po file management scripts from the Vim source tree.
+import-scripts:
+	@if test ! -d "$(VIM_SRC_DIR)"; then echo VIM_SRC_DIR not specified; exit 1; fi
+	cp "$(VIM_SRC_DIR)"/src/po/check.vim \
+	   "$(VIM_SRC_DIR)"/src/po/cleanup.vim \
+	   src/po/
 
 # Update Vim source directory.
 update-src-dir:


### PR DESCRIPTION
import and update the .po file management scripts from the Vim source tree.

---

src/po/check.vim と src/po/cleanup.vim を手軽に更新できるようにする make ターゲットを追加。
import-en-files と一緒にするのは、ちょっと違うなって感じたので別ターゲットにした。
将来的にまとめるなら `import-all: import-en-files import-scripts` を追加して、
ドキュメント更新すれば良さそう。